### PR TITLE
highlightMissingAltForImages

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -94,3 +94,9 @@ Hides some spam like "Who to Follow" from timelines.
 default: `0`
 
 Starts a count down and when reaches 0 sends the tweet that you just composed. It allows to abort tweets. Set this value to a number of choice, greater than `0` to activate this feature. When this feature is active a long press on the tweet button will send the tweet immediately.
+
+### highlightMissingAltForImages
+
+default: `true`
+
+Makes the alt text link in the compose dialog red to highlight the feature and hopefully encourage people to add descriptions to images.

--- a/index.user.js
+++ b/index.user.js
@@ -260,6 +260,21 @@
           btn = null
         }
       }
+    },
+    highlightMissingAltForImages: {
+      default: true,
+      test: ({ parsedUrl }) => parsedUrl.pathname === '/compose/tweet',
+      styles: [
+        `[href="/compose/tweet/alt_text"] {
+          border-radius: 2px;
+          padding: 0 0.25em;
+          background-color: #ca2055;
+          color: white
+        }`,
+        `[href="/compose/tweet/alt_text"] * {
+          color: white
+        }`
+      ]
     }
   }
 


### PR DESCRIPTION
This is just a first step, ideally I find time in the following days to show an alert dialog and abort tweeting when the description is missing.

<img width="623" alt="screenshot of the twitter's compose dialog link to add a description to images" src="https://user-images.githubusercontent.com/711311/57794960-25139580-7745-11e9-9efe-566cdeafe7e2.png">
