### PR TITLE
Image hover improvements

### DIFF
--- a/index.user.js
+++ b/index.user.js
@@ -295,20 +295,33 @@
       default: true,
       styles: [
         `
+        [data-testid="tweetPhoto"][aria-label] {
+          transition: margin 0.2s 0s ease-in-out;
+        }
         [data-testid="tweetPhoto"][aria-label]:hover {
           margin: 0 !important;
-          transition: margin 0.2s ease-in-out;
+          transition: margin 0.2s 1s ease-in-out;
         }
-        [data-testid="tweetPhoto"][aria-label]:hover:after {
+        [data-testid="tweetPhoto"][aria-label]:after {
           content: attr(aria-label);
+          opacity: 0;
           position: absolute;
           top: 0;
           background-color: rgba(0, 0, 0, 0.77);
           color: #fff;
+          word-break: break-word;
           margin: 0.7em;
           padding: 0.2em;
           border-radius: 0.2em;
           font-family: sans-serif;
+          transition: opacity 0.2s 0s ease-in-out;
+        }
+        [data-testid="tweetPhoto"][aria-label="Image"]:after {
+          display: none;
+        }
+        [data-testid="tweetPhoto"][aria-label]:hover:after {
+          opacity: 1;
+          transition: opacity 0.2s 1s ease-in-out;
         }
       `,
       ],

--- a/index.user.js
+++ b/index.user.js
@@ -298,11 +298,11 @@
         [data-testid="tweetPhoto"][aria-label] {
           transition: margin 0.2s 0s ease-in-out;
         }
-        [data-testid="tweetPhoto"][aria-label]:hover {
+        [data-testid="tweetPhoto"][aria-label]:not([aria-label="Image"]):hover {
           margin: 0 !important;
           transition: margin 0.2s 1s ease-in-out;
         }
-        [data-testid="tweetPhoto"][aria-label]:after {
+        [data-testid="tweetPhoto"][aria-label]:not([aria-label="Image"]):after {
           content: attr(aria-label);
           opacity: 0;
           position: absolute;
@@ -315,9 +315,6 @@
           border-radius: 0.2em;
           font-family: sans-serif;
           transition: opacity 0.2s 0s ease-in-out;
-        }
-        [data-testid="tweetPhoto"][aria-label="Image"]:after {
-          display: none;
         }
         [data-testid="tweetPhoto"][aria-label]:hover:after {
           opacity: 1;


### PR DESCRIPTION
1. `word-break: break-word;` fixes broken layout when alt text contains links
2. Don't show alt text if it says "Image" (twitter adds it by default, which is definitely not helpful)
3. Add 1 second delay before showing alt text so that it's not as distracting when you're just scrolling over a tweet or want to click on the image