### PR TITLE
Fix hanging "Suggested" header on profiles

### DIFF
--- a/index.user.js
+++ b/index.user.js
@@ -231,7 +231,7 @@
          [data-testid="primaryColumn"] [role="region"] [href^="/search?q="][href*="&f=user"],
          [href^="/i/related_users"],
          [href="/who_to_follow"],
-         [role="complementary"] {
+         [data-testid="primaryColumn"] [role="complementary"] {
             display: none
         }`,
       ],

--- a/index.user.js
+++ b/index.user.js
@@ -230,7 +230,8 @@
          [data-testid="primaryColumn"] [role="button"][data-testid="UserCell"],
          [data-testid="primaryColumn"] [role="region"] [href^="/search?q="][href*="&f=user"],
          [href^="/i/related_users"],
-         [href="/who_to_follow"] {
+         [href="/who_to_follow"],
+         [role="complementary"] {
             display: none
         }`,
       ],


### PR DESCRIPTION
<img width="361" alt="Screen Shot 2021-09-05 at 20 03 33" src="https://user-images.githubusercontent.com/10110245/132154940-19072b94-791b-4519-8862-074b20a3907a.png">

~~This also removes the "Who to follow" section from the sidebar for users who don't have `singleColumn` enabled.~~ Fixed in [`f6d52a4` (#8)](https://github.com/giuseppeg/refined-twitter-lite/pull/8/commits/f6d52a4349ade7c22ee9ff16137173b5fce871d6).